### PR TITLE
[#8] 애플리케이션 정상 동작 확인을 위한 health-check api 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/teamhyeok/legacysupermarket/status/api/controller/StatusController.java
+++ b/src/main/java/com/teamhyeok/legacysupermarket/status/api/controller/StatusController.java
@@ -1,0 +1,17 @@
+package com.teamhyeok.legacysupermarket.status.api.controller;
+
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/status")
+@RestController
+public class StatusController {
+
+    @GetMapping("/health")
+    public String healthCheck() {
+        return "I'm alive!";
+    }
+
+}

--- a/src/test/java/com/teamhyeok/legacysupermarket/status/api/controller/StatusControllerTest.java
+++ b/src/test/java/com/teamhyeok/legacysupermarket/status/api/controller/StatusControllerTest.java
@@ -1,0 +1,28 @@
+package com.teamhyeok.legacysupermarket.status.api.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest
+class StatusControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("/status/health 시 I'm alive!를 반환한다.")
+    void test1() throws Exception {
+        // expected
+        mockMvc.perform(get("/status/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("I'm alive!"));
+    }
+}


### PR DESCRIPTION
## a. 설명
>health-check api 구현 및 테스트 코드 작성

## b. 작업 내용
> 1. health-check api 구현
- HTTP GET 메서드
- url path는 `/status/health`
- 응답은 "I'm alive!"를 내려주도록
- 별도 비즈니스 로직, DB와의 상호작용 필요치 않아 @WebMvc 적용.
- MockMvc를 통해 가벼운 테스트 진행

## c. 작업 회고
> 1. WebMvc
- 처음엔 `WebMvc`라는 개념이 낯설어서 굳이 왜 써주지? 싶었다.
- 결국 Web, 그러니까 HTTP를 다루는 영역 정도만 로드하는 테스트여서 health-check의 경우처럼 동작 여부만 확인할 때 적용해봄직 했다.

```
[Web Mvc가 로드하는 대상]
- 컨트롤러(Controllers): 지정된 컨트롤러 또는 모든 컨트롤러를 테스트 환경에 로드합니다.
- 컨트롤러 어드바이스(Controller Advices): 예외 처리 등의 공통 로직을 처리하는 빈들도 함께 로드됩니다.
- 필터(Filters): HTTP 요청/응답에 대한 로깅, 인증 등을 처리하는 필터들을 포함할 수 있습니다.
- 웹 관련 구성 요소(Web-related Components): WebMvcConfigurer, HandlerMethodArgumentResolver 같은 웹 설정 관련 빈들
- JSON 컴포넌트(JsonComponents): JSON 직렬화/역직렬화를 위한 컴포넌트들이 포함될 수 있습니다.
```

> 2. MockMvc
- 기존 까지는 MockMvc를 그냥 아무생각 없이 '통합 테스트 할 때 request 만드는데 쓰는거구나 ..' 생각하고 있었다.
- 근데 오늘 생각해보니 MockMvc가 결국 SpringMvc를 의미하는 목킹하는 개념이라는 사실을 깨달았다.

## d. 기타 사항
> .. 그 외 특이사항 없음
